### PR TITLE
Fix design issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
  and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.2] - 2019-05-13
 ### Fixed
 - Size of the options dots icon in the action menu of the list item in mobile mode.
 - Default list's height in mobile mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
  and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.1.2] - 2019-05-13
 ### Fixed
 - Size of the options dots icon in the action menu of the list item in mobile mode.
 - Default list's height in mobile mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
  and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Size of the options dots icon in the action menu of the list item in mobile mode.
+- Default list's height in mobile mode.
 
 ## [0.1.1] - 2019-05-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.1.3] - 2019-05-13
+
 ## [0.1.2] - 2019-05-13
 ### Fixed
 - Size of the options dots icon in the action menu of the list item in mobile mode.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "wishlist",
   "title": "Wishlist",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "defaultLocale": "pt-BR",
   "builders": {
     "react": "3.x",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "wishlist",
   "title": "Wishlist",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "defaultLocale": "pt-BR",
   "builders": {
     "react": "3.x",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "wishlist",
   "title": "Wishlist",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "defaultLocale": "pt-BR",
   "builders": {
     "react": "3.x",

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -28,6 +28,8 @@ interface ListItemState {
   showDeleteDialog?: boolean
 }
 
+const ICON_SIZE = 20
+
 class ListItem extends Component<ListItemProps, {}> {
   public state: ListItemState = {}
 
@@ -79,7 +81,7 @@ class ListItem extends Component<ListItemProps, {}> {
       ph4: !showMenuOptions,
     })
     const nameClassName = classNames('w-100 mh4 mv1', {
-      'flex justify-center pv1': isDefault,
+      'flex justify-center pv2': isDefault,
     })
     return (
       <div className={className}>
@@ -105,7 +107,7 @@ class ListItem extends Component<ListItemProps, {}> {
                   hideCaretIcon
                   buttonProps={{
                     variation: 'tertiary',
-                    icon: <IconOptionsDots size={20} />,
+                    icon: <IconOptionsDots size={ICON_SIZE} />,
                     size: 'small',
                   }}
                 />

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -72,7 +72,7 @@ class ListItem extends Component<ListItemProps, {}> {
       onSelected,
     } = this.props
     const { showDeleteDialog } = this.state
-    const className = classNames('w-100 flex flex-row items-center pv3', {
+    const className = classNames('w-100 flex flex-row items-center pv4', {
       'bg-action-secondary': isDefault,
       'bt b--muted-4': !hideBorders,
       'c-emphasis': hideBorders && isSelected,

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -70,11 +70,13 @@ class ListItem extends Component<ListItemProps, {}> {
       onSelected,
     } = this.props
     const { showDeleteDialog } = this.state
-    const className = classNames('w-100 flex flex-row items-center ph4 pv3', {
+    const className = classNames('w-100 flex flex-row items-center pv3', {
       'bg-action-secondary': isDefault,
       'bt b--muted-4': !hideBorders,
       'c-emphasis': hideBorders && isSelected,
       'c-muted-2': !isSelected || !hideBorders,
+      pl4: showMenuOptions,
+      ph4: !showMenuOptions,
     })
     const nameClassName = classNames('w-100 mh4 mv1', {
       'flex justify-center pv1': isDefault,
@@ -103,7 +105,7 @@ class ListItem extends Component<ListItemProps, {}> {
                   hideCaretIcon
                   buttonProps={{
                     variation: 'tertiary',
-                    icon: <IconOptionsDots color="c-action-primary" />,
+                    icon: <IconOptionsDots size={20} />,
                     size: 'small',
                   }}
                 />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix size of the `OptionsDotsIcon` and the default list's height. Both in the mobile mode.

 #### What problem is this solving?
![image (1)](https://user-images.githubusercontent.com/12852518/57541178-cf924f80-7324-11e9-9706-abf3b3ad8eda.png)

 #### How should this be manually tested?
Go to the mobile mode, click in the heart icon to add a product to a list and then go to see all lists.
[Click here to access the workspace.](https://vitoria--storecomponents.myvtex.com/)

 #### Screenshots or example usage
![image](https://user-images.githubusercontent.com/12852518/57541386-40396c00-7325-11e9-8834-aefd60df6baa.png)

 #### Types of changes

 * [X] Bug fix (a non-breaking change which fixes an issue)
 * [ ] New feature (a non-breaking change which adds functionality)
 * [ ] Breaking change (fix or feature that would cause existing functionality to change)
 * [ ] Requires change to documentation, which has been updated accordingly.