### PR TITLE
Removed `Copy to` option in the dropdown of the item in wish list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
  and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.4] - 2019-05-13
 ### Fixed
 - Removed `Copy to` option in the dropdown of the product in wish list.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Removed `Copy to` option in the dropdown of the item in wish list.
+- Removed `Copy to` option in the dropdown of the product in wish list.
 
 ## [0.1.3] - 2019-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
  and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed `Copy to` option in the dropdown of the item in wish list.
 
 ## [0.1.3] - 2019-05-13
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "wishlist",
   "title": "Wishlist",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "defaultLocale": "pt-BR",
   "builders": {
     "react": "3.x",

--- a/react/components/ListDetails/ItemDetails.tsx
+++ b/react/components/ListDetails/ItemDetails.tsx
@@ -81,7 +81,7 @@ class ItemDetails extends Component<ItemDetailsProps, ItemDetailsState> {
           <div className="mt2 mr3">
             {lists &&
               (isCopying ? (
-                renderLoading()
+                <div className="mr4">{renderLoading()}</div>
               ) : (
                 <ActionMenu
                   label={intl.formatMessage({ id: 'wishlist-copy-to' })}

--- a/react/components/ListDetails/ItemDetails.tsx
+++ b/react/components/ListDetails/ItemDetails.tsx
@@ -9,9 +9,9 @@ import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
 import {
   ButtonWithIcon,
   Checkbox,
-  Dropdown,
   IconDelete,
   withToast,
+  ActionMenu
 } from 'vtex.styleguide'
 import renderLoading from '../Loading'
 
@@ -70,26 +70,27 @@ class ItemDetails extends Component<ItemDetailsProps, ItemDetailsState> {
           {isLoading ? (
             <div className="mr4">{renderLoading()}</div>
           ) : (
-            <ButtonWithIcon
-              icon={deleteIcon}
-              variation="tertiary"
-              onClick={this.handleItemRemove}
-            />
+            <div className="ph3">
+              <ButtonWithIcon
+                icon={deleteIcon}
+                variation="tertiary"
+                onClick={this.handleItemRemove}
+              />
+            </div>
           )}
           <div className="mt2 mr3">
             {lists &&
               (isCopying ? (
                 renderLoading()
               ) : (
-                <Dropdown
-                  variation="inline"
-                  size="large"
-                  placeholder={intl.formatMessage({ id: 'wishlist-copy-to' })}
-                  options={this.dropdownOptionsShape(lists)}
-                  disabled={!(lists && lists.length > 0)}
-                  onChange={(_: {}, value: string) =>
-                    this.copyProductToList(value)
-                  }
+                <ActionMenu
+                  label={intl.formatMessage({ id: 'wishlist-copy-to' })}
+                  options={this.getActionMenuOptions(lists)}
+                  buttonProps={{
+                    variation: 'tertiary',
+                    size: 'small',
+                    disabled: !(lists && lists.length > 0),
+                  }}
                 />
               ))}
           </div>
@@ -112,9 +113,11 @@ class ItemDetails extends Component<ItemDetailsProps, ItemDetailsState> {
     )
   }
 
-  private dropdownOptionsShape = (lists: List[]): DropDownItem[] => {
-    return map(({ id, name }) => ({ value: id, label: name }), lists)
-  }
+  private getActionMenuOptions = (lists: List[]) : ActionMenuItem[] =>
+    lists.map(({ id, name }) => ({
+      label: name,
+      onClick: () => this.copyProductToList(String(id)),
+    }))
 
   private normalizeProduct = (product: Product | undefined): {} | null => {
     if (!product) {

--- a/react/typings/global.ts
+++ b/react/typings/global.ts
@@ -99,7 +99,7 @@ interface ListItemWithProduct {
   product: Product
 }
 
-interface DropDownItem {
-  value?: string
+interface ActionMenuItem {
   label?: string
+  onClick: () => void
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

In the dropdown options of itens in wish list, shows the `Copy to` option.

 #### What problem is this solving?

Removed `Copy to` option in the dropdown menu of  the itens in wish list.

 #### How should this be manually tested?

[workspace](https://thaynan--storecomponents.myvtex.com/lists)

 #### Types of changes

 * [x] Bug fix (a non-breaking change which fixes an issue)
 * [ ] New feature (a non-breaking change which adds functionality)
 * [ ] Breaking change (fix or feature that would cause existing functionality to change)
 * [ ] Requires change to documentation, which has been updated accordingly.