### PR TITLE
Adds @context to GraphQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
  and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Include `@context` directive in GraphQL queries and mutations.
 
 ## [0.1.7] - 2019-05-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
  and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.8] - 2019-05-16
 ### Fixed
 - Include `@context` directive in GraphQL queries and mutations.
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "wishlist",
   "title": "Wishlist",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "defaultLocale": "pt-BR",
   "builders": {
     "react": "3.x",

--- a/react/graphql/mutations/createList.gql
+++ b/react/graphql/mutations/createList.gql
@@ -1,10 +1,17 @@
-mutation createList($name: String!, $isPublic: Boolean, $isEditable: Boolean, $items: [ListItemInput]) {
-  createList(list: {
-    name: $name,
-    isPublic: $isPublic
-    items: $items
-    isEditable: $isEditable
-  }) {
+mutation createList(
+  $name: String!
+  $isPublic: Boolean
+  $isEditable: Boolean
+  $items: [ListItemInput]
+) {
+  createList(
+    list: {
+      name: $name
+      isPublic: $isPublic
+      items: $items
+      isEditable: $isEditable
+    }
+  ) @context(provider: "vtex.store-graphql") {
     id
     name
     owner

--- a/react/graphql/mutations/deleteList.gql
+++ b/react/graphql/mutations/deleteList.gql
@@ -1,5 +1,5 @@
 mutation deleteList($id: ID!) {
-    deleteList(id: $id) {
-        id
-    }
+  deleteList(id: $id) @context(provider: "vtex.store-graphql") {
+    id
+  }
 }

--- a/react/graphql/mutations/updateList.gql
+++ b/react/graphql/mutations/updateList.gql
@@ -1,5 +1,5 @@
 mutation updateList($id: ID!, $list: ListInput) {
-  updateList(id: $id, list: $list) {
+  updateList(id: $id, list: $list) @context(provider: "vtex.store-graphql") {
     id
     name
     isPublic

--- a/react/graphql/queries/getList.gql
+++ b/react/graphql/queries/getList.gql
@@ -1,5 +1,5 @@
-query getList($id: ID){
-  list(id: $id) {
+query getList($id: ID) {
+  list(id: $id) @context(provider: "vtex.store-graphql") {
     id
     name
     isPublic

--- a/react/graphql/queries/getListDetails.gql
+++ b/react/graphql/queries/getListDetails.gql
@@ -1,5 +1,5 @@
 query getListDetails($id: ID) {
-  list(id: $id) {
+  list(id: $id) @context(provider: "vtex.store-graphql") {
     name
     isEditable
     isPublic
@@ -10,42 +10,42 @@ query getListDetails($id: ID) {
       quantity
       product {
         productId
-    productName
-    description
-    categories
-    link
-    linkText
-    brand
-    items {
-      name
-      itemId
-      referenceId {
-        Value
-      }
-      images {
-        imageUrl
-        imageTag
-      }
-      sellers {
-        sellerId
-        commertialOffer {
-          Installments {
+        productName
+        description
+        categories
+        link
+        linkText
+        brand
+        items {
+          name
+          itemId
+          referenceId {
             Value
-            InterestRate
-            TotalValuePlusInterestRate
-            NumberOfInstallments
-            Name
           }
-          AvailableQuantity
-          Price
-          ListPrice
+          images {
+            imageUrl
+            imageTag
+          }
+          sellers {
+            sellerId
+            commertialOffer {
+              Installments {
+                Value
+                InterestRate
+                TotalValuePlusInterestRate
+                NumberOfInstallments
+                Name
+              }
+              AvailableQuantity
+              Price
+              ListPrice
+            }
+          }
         }
-      }
-    }
-    productClusters {
-      id
-      name
-    }
+        productClusters {
+          id
+          name
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes the problem with a conflicting name of a graphql query.
![image](https://user-images.githubusercontent.com/18706156/57875927-74f86800-77ea-11e9-8676-041ec898a664.png)

Test it [here](https://poa--storecomponents.myvtex.com/)

Using it in [master](https://storecomponents.myvtex.com/) will break 