### PR TITLE
Make it work with product-summary.shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.1.11] - 2019-06-10
+
 ### Fixed
 
 - Make it work with `product-summary.shelf` only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Make it work with `product-summary.shelf` only.
+
 ## [0.1.10] - 2019-05-17
 ### Changed
 - Applying the new i18n configuration.

--- a/README.md
+++ b/README.md
@@ -121,9 +121,6 @@ This app has an interface that describes what rules must be implemented by a blo
     "after": [
       "footer"
     ]
-  },
-  "footer": {
-     "component": "Footer"
   }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,8 @@
     "vtex.product-summary": "2.x",
     "vtex.product-details": "1.x",
     "vtex.store": "2.x",
+    "vtex.store-footer": "2.x",
     "vtex.store-header": "2.x"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "wishlist",
   "title": "Wishlist",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "defaultLocale": "pt-BR",
   "builders": {
     "react": "3.x",

--- a/react/Footer.tsx
+++ b/react/Footer.tsx
@@ -1,5 +1,0 @@
-/**
- * This component is necessary to hide the inherit footer
- * from the store.
- */
-export default () => null

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,7 +1,6 @@
 {
   "addon-summary-btn.add-to-list": {
-    "component": "AddProductBtn",
-    "required": ["lists", "product-summary"]
+    "component": "AddProductBtn"
   },
   "addon-details-btn.add-to-list": {
     "component": "AddProductBtn",
@@ -26,8 +25,5 @@
     "after": [
       "footer"
     ]
-  },
-  "footer": {
-     "component": "Footer"
   }
 }

--- a/store/plugins.json
+++ b/store/plugins.json
@@ -1,4 +1,4 @@
 {
   "product-details > addon-details-btn": "addon-details-btn.add-to-list",
-  "product-summary > addon-summary-btn": "addon-summary-btn.add-to-list"
+  "product-summary-add-to-list-button > addon-summary-btn": "addon-summary-btn.add-to-list"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Related https://github.com/vtex-apps/product-summary/pull/164

 #### What problem is this solving?

It was not possible to use wishlist with `product-summary.shelf`.

 #### How should this be manually tested?

https://breno--storecomponents.myvtexdev.com/electronics?disableUserLand

 #### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/59222377-bf79c400-8b9f-11e9-9d24-143792202398.png)

 #### Types of changes

 * [x] Bug fix (a non-breaking change which fixes an issue)
 * [ ] New feature (a non-breaking change which adds functionality)
 * [ ] Breaking change (fix or feature that would cause existing functionality to change)
 * [ ] Requires change to documentation, which has been updated accordingly.