### PR TITLE
fix duplicate query name

### DIFF
--- a/react/graphql/queries/getListsByOwner.gql
+++ b/react/graphql/queries/getListsByOwner.gql
@@ -1,4 +1,4 @@
-query getList($owner: ID!) {
+query getListsByOwner($owner: ID!) {
   listsByOwner(owner: $owner) @context(provider: "vtex.store-graphql") {
     id
     name


### PR DESCRIPTION
#### What is the purpose of this pull request?
a graphql query with duplicated name.
 <!--- Describe your changes in detail. -->
renamed the query name, because it was duplicated, 'console was warning'.
 #### What problem is this solving?
App is now running.
 <!--- What is the motivation and context for this change? -->
App to start working.
 #### How should this be manually tested?
By making the query.
 #### Screenshots or example usage
none.
 #### Types of changes

 * [x] Bug fix (a non-breaking change which fixes an issue)
 * [ ] New feature (a non-breaking change which adds functionality)
 * [ ] Breaking change (fix or feature that would cause existing functionality to change)
 * [ ] Requires change to documentation, which has been updated accordingly.